### PR TITLE
fix: fix downloading INSPIRE schemas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,7 +378,14 @@ class INSPIREDownloadTask extends DefaultTask {
 
     File applicationtempschemas = new File(temporaryDir, 'application-schemas-main')
     File tempRoot = new File(applicationtempschemas, 'tmp-schemas')
-    def versions = ['2021.1', '2021.2', '2022.1', '2022.2', '2023.1']
+    def versions = new File(applicationtempschemas, "schemas").listFiles().findAll { file ->
+      file.isDirectory() && file.name =~ /^[2-9][0-9]{3}\.\d+$/
+    }.collect { it.name }.sort()
+    println "Identified versions in 'schemas': ${versions.join(', ')}"
+    // safety check
+    assert versions.contains('2023.1')
+    assert versions[0] == '2021.1'
+
     // copy all versions in order
     versions.each { v ->
       project.copy {

--- a/build.gradle
+++ b/build.gradle
@@ -388,24 +388,23 @@ class INSPIREDownloadTask extends DefaultTask {
       }
     }
 
+    // copy all files from main folder
     project.copy {
       from new File(applicationtempschemas, "schemas")
       into tempRoot
       include '**/*'
     }
 
-    File applicationTempSchemasfolder = new File(applicationtempschemas, 'schemas')
-    applicationTempSchemasfolder.deleteDir()
-    File applicationTempSchemasfolderNew = new File(applicationtempschemas, 'schemas')
-    tempRoot.renameTo(applicationTempSchemasfolderNew)
+    // delete schemas folder and move schemas aggregated in temp folder to its location
+    File schemasFolder = new File(applicationtempschemas, 'schemas')
+    schemasFolder.deleteDir()
+    tempRoot.renameTo(schemasFolder)
 
-    // List all files in the subfolder
-    def files = applicationtempschemas.listFiles()
-
-    // Copy each file to the parent folder
-    files.each { file ->
-      def destination = new File(targetDir, file.name)
-      file.renameTo(destination)
+    // copy files to target folder
+    project.copy {
+      from applicationtempschemas
+      into targetDir
+      include '**/*'
     }
 
     // create application schema index file (used by hale-studio specific bundle)


### PR DESCRIPTION
The previous method to place the schemas in the target folder did not
fail to include the latest changes.

Also:
- feat: detect INSPIRE schemas versions automatically